### PR TITLE
properly initialize cachedDiffU in constructor

### DIFF
--- a/src/Photons.ts
+++ b/src/Photons.ts
@@ -34,7 +34,7 @@ export default class Photons {
   constructor(sizeX: number, sizeY: number, vector: Vector, operators: IXYOperator[] = []) {
     this.vector = vector
     this.operators = operators
-    this.cachedDiffU = Photons.singlePhotonInteraction(sizeX, sizeY, operators)
+    this.cachedDiffU = Photons.singlePhotonInteractionDiff(sizeX, sizeY, operators)
     this.dimX = Dimension.position(sizeX, 'x')
     this.dimY = Dimension.position(sizeY, 'y')
   }

--- a/tests/Photons.test.ts
+++ b/tests/Photons.test.ts
@@ -34,11 +34,11 @@ describe('Photons', () => {
     const photons = Photons.emptySpace(3, 5).addPhotonFromIndicator(0, 2, '>', 'V')
 
     expect(photons.ketString()).toBe('(1.00 +0.00i) |0,2,>,V⟩')
-    photons.propagatePhotons()
+    photons.propagatePhotons().actOnSinglePhotons()
     expect(photons.ketString()).toBe('(1.00 +0.00i) |1,2,>,V⟩')
-    photons.propagatePhotons()
+    photons.propagatePhotons().actOnSinglePhotons()
     expect(photons.ketString()).toBe('(1.00 +0.00i) |2,2,>,V⟩')
-    photons.propagatePhotons()
+    photons.propagatePhotons().actOnSinglePhotons()
     expect(photons.ketString()).toBe('')
   })
 
@@ -46,11 +46,11 @@ describe('Photons', () => {
     const photons = Photons.emptySpace(3, 5).addPhotonFromIndicator(0, 2, '>', 'V')
 
     expect(photons.ketString()).toBe('(1.00 +0.00i) |0,2,>,V⟩')
-    photons.propagatePhotonsWithOperator()
+    photons.propagatePhotonsWithOperator().actOnSinglePhotons()
     expect(photons.ketString()).toBe('(1.00 +0.00i) |1,2,>,V⟩')
-    photons.propagatePhotonsWithOperator()
+    photons.propagatePhotonsWithOperator().actOnSinglePhotons()
     expect(photons.ketString()).toBe('(1.00 +0.00i) |2,2,>,V⟩')
-    photons.propagatePhotonsWithOperator()
+    photons.propagatePhotonsWithOperator().actOnSinglePhotons()
     expect(photons.ketString()).toBe('')
   })
 

--- a/tests/Photons.test.ts
+++ b/tests/Photons.test.ts
@@ -34,11 +34,11 @@ describe('Photons', () => {
     const photons = Photons.emptySpace(3, 5).addPhotonFromIndicator(0, 2, '>', 'V')
 
     expect(photons.ketString()).toBe('(1.00 +0.00i) |0,2,>,V⟩')
-    photons.propagatePhotons().actOnSinglePhotons()
+    photons.propagatePhotons()
     expect(photons.ketString()).toBe('(1.00 +0.00i) |1,2,>,V⟩')
-    photons.propagatePhotons().actOnSinglePhotons()
+    photons.propagatePhotons()
     expect(photons.ketString()).toBe('(1.00 +0.00i) |2,2,>,V⟩')
-    photons.propagatePhotons().actOnSinglePhotons()
+    photons.propagatePhotons()
     expect(photons.ketString()).toBe('')
   })
 
@@ -46,11 +46,23 @@ describe('Photons', () => {
     const photons = Photons.emptySpace(3, 5).addPhotonFromIndicator(0, 2, '>', 'V')
 
     expect(photons.ketString()).toBe('(1.00 +0.00i) |0,2,>,V⟩')
-    photons.propagatePhotonsWithOperator().actOnSinglePhotons()
+    photons.propagatePhotonsWithOperator()
     expect(photons.ketString()).toBe('(1.00 +0.00i) |1,2,>,V⟩')
-    photons.propagatePhotonsWithOperator().actOnSinglePhotons()
+    photons.propagatePhotonsWithOperator()
     expect(photons.ketString()).toBe('(1.00 +0.00i) |2,2,>,V⟩')
-    photons.propagatePhotonsWithOperator().actOnSinglePhotons()
+    photons.propagatePhotonsWithOperator()
+    expect(photons.ketString()).toBe('')
+  })
+
+  it('interacts a photon with no effect on empty board', () => {
+    const photons = Photons.emptySpace(3, 5).addPhotonFromIndicator(0, 2, '>', 'V')
+
+    expect(photons.ketString()).toBe('(1.00 +0.00i) |0,2,>,V⟩')
+    photons.propagatePhotons().actOnSinglePhotons()
+    expect(photons.ketString()).toBe('(1.00 +0.00i) |1,2,>,V⟩')
+    photons.propagatePhotons().actOnSinglePhotons()
+    expect(photons.ketString()).toBe('(1.00 +0.00i) |2,2,>,V⟩')
+    photons.propagatePhotons().actOnSinglePhotons()
     expect(photons.ketString()).toBe('')
   })
 


### PR DESCRIPTION
This fixes the issue with nonsensical probabilities in the QG board-perf branch.

The tests were modified first to repliacte the issue seen in the game.