### PR TITLE
Dimension equality check and loop handrolling optimizations

### DIFF
--- a/src/Complex.ts
+++ b/src/Complex.ts
@@ -50,7 +50,7 @@ export default class Complex {
    * @returns number
    */
   abs2(): number {
-    return Math.pow(this.re, 2) + Math.pow(this.im, 2)
+    return this.re * this.re + this.im * this.im
   }
 
   /**
@@ -58,7 +58,7 @@ export default class Complex {
    * @returns absolute value
    */
   abs(): number {
-    return Math.sqrt(Math.pow(this.re, 2) + Math.pow(this.im, 2))
+    return Math.sqrt(this.re * this.re + this.im * this.im)
   }
 
   /**
@@ -148,8 +148,9 @@ export default class Complex {
    * @returns z
    */
   normalize(): Complex {
-    if (this.r !== 0) {
-      return new Complex(this.re / this.r, this.im / this.r)
+    const norm = this.r
+    if (norm !== 0) {
+      return new Complex(this.re / norm, this.im / norm)
     } else {
       throw new Error('Cannot normalize a 0 length vector...')
     }
@@ -191,12 +192,11 @@ export default class Complex {
   }
 
   /**
-   * Check if a complex number is zero
-   * @param eps tolerance for the Euclidean norm
+   * Check if a complex number is very close zero (norm at most 1e-6 from zero)
    * @return z1 ~= 0
    */
-  isAlmostZero(eps = 1e-6): boolean {
-    return this.r < eps
+  isAlmostZero(): boolean {
+    return this.abs2() < 1e-12
   }
 
   /**
@@ -204,7 +204,7 @@ export default class Complex {
    * @return z1.r === 1
    */
   isNormal(): boolean {
-    return this.r === 1
+    return this.abs2() === 1
   }
 
   /**

--- a/src/Dimension.ts
+++ b/src/Dimension.ts
@@ -30,20 +30,24 @@ export default class Dimension {
     this.coordNames = coordNames // later, we may make it optional
     this.size = size
 
-    const identityKey = this.identityKey()
-    let identity = identityMap.get(identityKey)
+    const hashKey = this.hashKey()
+    let identity = identityMap.get(hashKey)
     if (identity == null) {
       identity = Symbol(name)
-      identityMap.set(identityKey, identity)
+      identityMap.set(hashKey, identity)
     }
     this.identity = identity
   }
 
   /**
-   * A string used for dimension identification during comparison.
-   * Mapped into symbol on creation to avoid costly string compares.
+   * A string used for dimension equality test.
+   *
+   * @remark do not assume any particular format. The only important quality of this
+   * value is that it fully encodes all relevant dimension data and can be used as a hash key
+   *
+   * @returns identification string
    */
-  private identityKey(): string {
+  private hashKey(): string {
     return `${this.name}-${this.size}-${this.coordNames.length}-${this.coordNames
       .map((n, i) => `#${i}-${n}`)
       .join('-')}`

--- a/src/Operator.ts
+++ b/src/Operator.ts
@@ -740,7 +740,7 @@ export default class Operator {
    */
   static add(ops: Operator[]): Operator {
     if (ops.length === 0) {
-      throw new Error('addMany requires at least one operator')
+      throw new Error('add requires at least one operator')
     }
     if (ops.length === 1) {
       return ops[0]
@@ -754,13 +754,18 @@ export default class Operator {
 
     // this function is very hot, so loops are hand-rolled for performance
     const entriesByCoord: Record<string, OperatorEntry> = {}
+
+    // hash entries from first operator by their coordinates
     for (const entry of m1.entries) {
       entriesByCoord[entry.coordKey()] = entry
     }
+    // for every next operator in the sum
     for (const m2 of rest) {
       for (const entry of m2.entries) {
         const key = entry.coordKey()
         if (entriesByCoord.hasOwnProperty(key)) {
+          // if this entry's coordinates are already in the hashmap,
+          // calculate the sum and store back, rejecting near-zero results.
           const value = entriesByCoord[key].value.add(entry.value)
           if (value.isAlmostZero()) {
             delete entriesByCoord[key]
@@ -768,6 +773,7 @@ export default class Operator {
             entriesByCoord[key] = new OperatorEntry(entry.coordOut, entry.coordIn, value)
           }
         } else {
+          // this is the first entry under given coordinates, so store it directly
           entriesByCoord[key] = entry
         }
       }

--- a/src/Operator.ts
+++ b/src/Operator.ts
@@ -109,15 +109,6 @@ export default class Operator {
   }
 
   /**
-   * Create a copy of the vector.
-   * @todo Make it more lightweight than using lodash.
-   * FIXME: Is this operation even necessary? Operator should never be mutated anyway.
-   */
-  copy(): Operator {
-    return _.cloneDeep(this)
-  }
-
-  /**
    * Elementwise complex conjugation (no transpose!).
    * https://en.wikipedia.org/wiki/Complex_conjugate
    * @returns A^* - simple conjugate of an operator.

--- a/src/OperatorEntry.ts
+++ b/src/OperatorEntry.ts
@@ -6,9 +6,9 @@ import { coordsFromIndex } from './helpers'
  * To be used only within a Operator object, or to create such.
  */
 export default class OperatorEntry {
-  coordOut: number[]
-  coordIn: number[]
-  value: Complex
+  readonly coordOut: number[]
+  readonly coordIn: number[]
+  readonly value: Complex
 
   /**
    * Creates a VectorEntry from output and input coordinates, and value.
@@ -40,6 +40,13 @@ export default class OperatorEntry {
       `Sparse operator entry [${this.coordOut.toString()}, ${this.coordIn.toString()}] ` +
       `has value ${this.value.toString()}`
     )
+  }
+
+  /**
+   * Entry coordinates in string representation. Can be used for hashing.
+   */
+  coordKey(): string {
+    return `${this.coordOut.toString()}-${this.coordIn.toString()}`
   }
 
   /**

--- a/src/Vector.ts
+++ b/src/Vector.ts
@@ -153,20 +153,27 @@ export default class Vector {
 
     // this function is very hot, so loops are hand-rolled
     const entriesByCoord: Record<string, VectorEntry> = {}
+
+    // hash entries from v1 by coordinates
     for (const entry of v1.entries) {
       const key = entry.coord.toString()
       entriesByCoord[key] = entry
     }
+
     for (const entry of v2.entries) {
+      // look up entries by coordiantes from second vector
       const key = entry.coord.toString()
       if (entriesByCoord.hasOwnProperty(key)) {
+        // add values under the same coordinates
         const value = entriesByCoord[key].value.add(entry.value)
         if (value.isAlmostZero()) {
+          // remove near-zero sum results
           delete entriesByCoord[key]
         } else {
           entriesByCoord[key] = new VectorEntry(entry.coord, value)
         }
       } else {
+        // entry didn't exist in v1, sum is just a value from v2
         entriesByCoord[key] = entry
       }
     }
@@ -198,13 +205,17 @@ export default class Vector {
     // this function is very hot, so loops are hand-rolled for performance
     let dotSum = Cx(0, 0)
     const entriesByCoord: Record<string, VectorEntry> = {}
+    // hash entries from v1 by coordinates
     for (const entry of v1.entries) {
       const key = entry.coord.toString()
       entriesByCoord[key] = entry
     }
+
+    // lookup entries based on coordinates from v2
     for (const entry of v2.entries) {
       const key = entry.coord.toString()
       if (entriesByCoord.hasOwnProperty(key)) {
+        // for every entry existing on both v1 and v2, add their product to the dot
         dotSum = dotSum.add(entriesByCoord[key].value.mul(entry.value))
       }
     }

--- a/src/Vector.ts
+++ b/src/Vector.ts
@@ -28,9 +28,10 @@ export default class Vector {
     this.entries = entries
     this.dimensions = dimensions
 
-    this.entries.forEach((entry) => {
-      checkCoordsSizesCompability(entry.coord, this.size)
-    })
+    const size = this.size
+    for (const entry of entries) {
+      checkCoordsSizesCompability(entry.coord, size)
+    }
   }
 
   /**
@@ -46,7 +47,7 @@ export default class Vector {
    * FIXME: size and totalSize is confusing, rename to length or size, sizes?
    */
   get totalSize(): number {
-    return this.size.reduce((a, b) => a * b)
+    return this.dimensions.reduce((a, dim) => a * dim.size, 1)
   }
 
   /**
@@ -150,18 +151,27 @@ export default class Vector {
 
     Dimension.checkDimensions(v1.dimensions, v2.dimensions)
 
-    const entries = _.chain(v1.entries.concat(v2.entries))
-      .groupBy((entry: VectorEntry) => entry.coord.toString())
-      .values()
-      .map((grouped: VectorEntry[]) => {
-        const coord = [...grouped[0].coord]
-        const value = grouped.map((entry) => entry.value).reduce((a, b) => a.add(b))
-        return new VectorEntry(coord, value)
-      })
-      .filter((entry) => !entry.value.isAlmostZero())
-      .value()
+    // this function is very hot, so loops are hand-rolled
+    const entriesByCoord: Record<string, VectorEntry> = {}
+    for (const entry of v1.entries) {
+      const key = entry.coord.toString()
+      entriesByCoord[key] = entry
+    }
+    for (const entry of v2.entries) {
+      const key = entry.coord.toString()
+      if (entriesByCoord.hasOwnProperty(key)) {
+        const value = entriesByCoord[key].value.add(entry.value)
+        if (value.isAlmostZero()) {
+          delete entriesByCoord[key]
+        } else {
+          entriesByCoord[key] = new VectorEntry(entry.coord, value)
+        }
+      } else {
+        entriesByCoord[key] = entry
+      }
+    }
 
-    return new Vector(entries, v1.dimensions)
+    return new Vector(Object.values(entriesByCoord), v1.dimensions)
   }
 
   /**
@@ -185,20 +195,20 @@ export default class Vector {
 
     Dimension.checkDimensions(v1.dimensions, v2.dimensions)
 
-    const result = _.chain(v1.entries.concat(v2.entries))
-      .groupBy((entry: VectorEntry) => entry.coord.toString())
-      .values()
-      .map((grouped: VectorEntry[]) => {
-        if (grouped.length === 2) {
-          return grouped[0].value.mul(grouped[1].value)
-        } else {
-          return Cx(0, 0)
-        }
-      })
-      .reduce((a, b) => a.add(b), Cx(0))
-      .value()
-
-    return result
+    // this function is very hot, so loops are hand-rolled for performance
+    let dotSum = Cx(0, 0)
+    const entriesByCoord: Record<string, VectorEntry> = {}
+    for (const entry of v1.entries) {
+      const key = entry.coord.toString()
+      entriesByCoord[key] = entry
+    }
+    for (const entry of v2.entries) {
+      const key = entry.coord.toString()
+      if (entriesByCoord.hasOwnProperty(key)) {
+        dotSum = dotSum.add(entriesByCoord[key].value.mul(entry.value))
+      }
+    }
+    return dotSum
   }
 
   /**
@@ -410,7 +420,7 @@ export default class Vector {
   static fromArray(denseArray: Complex[], dimensions: Dimension[], removeZeros = true): Vector {
     // Get size vector from dimensions
     const sizes = dimensions.map((dimension) => dimension.size)
-    const totalSize = sizes.reduce((a, b) => a * b)
+    const totalSize = dimensions.reduce((a, dim) => a * dim.size, 1)
     if (denseArray.length !== totalSize) {
       throw new Error(`Dimension inconsistency: entry count ${denseArray.length} != total: ${totalSize}`)
     }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -58,11 +58,13 @@ export function checkCoordsSizesCompability(coords: number[], sizes: number[]): 
   if (coords.length !== sizes.length) {
     throw new Error(`Coordinates [${coords}] incompatible with sizes [${sizes}].`)
   }
-  coords.forEach((c, i) => {
+
+  for (let i = 0; i < coords.length; i++) {
+    const c = coords[i]
     if (c < 0 || c >= sizes[i]) {
       throw new Error(`Coordinates [${coords}] incompatible with sizes [${sizes}].`)
     }
-  })
+  }
 }
 
 /**

--- a/tests/Dimension.test.ts
+++ b/tests/Dimension.test.ts
@@ -15,9 +15,21 @@ describe('Dimension', () => {
     const polarization = Dimension.polarization()
     const direction = Dimension.direction()
     const spin = Dimension.spin()
-    expect(polarization).toEqual({ coordNames: ['H', 'V'], name: 'polarization', size: 2 })
-    expect(direction).toEqual({ coordNames: ['>', '^', '<', 'v'], name: 'direction', size: 4 })
-    expect(spin).toEqual({ coordNames: ['u', 'd'], name: 'spin', size: 2 })
+    expect(polarization).toMatchObject({ coordNames: ['H', 'V'], name: 'polarization', size: 2 })
+    expect(direction).toMatchObject({ coordNames: ['>', '^', '<', 'v'], name: 'direction', size: 4 })
+    expect(spin).toMatchObject({ coordNames: ['u', 'd'], name: 'spin', size: 2 })
+  })
+
+  it('should equate identical dimensions', () => {
+    const polarization1 = Dimension.polarization()
+    const polarization2 = Dimension.polarization()
+    expect(polarization1.isEqual(polarization2)).toBeTruthy()
+  })
+
+  it('should not equate different dimensions', () => {
+    const polarization = Dimension.polarization()
+    const direction = Dimension.direction()
+    expect(polarization.isEqual(direction)).toBeFalsy()
   })
 
   it('should forbid creating dimensions with a mismatched length of element and size', () => {

--- a/tests/Operator.test.ts
+++ b/tests/Operator.test.ts
@@ -429,23 +429,6 @@ describe('Sparse Complex Operator', () => {
     )
   })
 
-  it('creates a operator copy', () => {
-    const op = Operator.fromSparseCoordNames(
-      [
-        ['dH', 'dH', Cx(0, 2)],
-        ['dH', 'uH', Cx(-1, -1)],
-        ['dV', 'uH', Cx(0.5, 2.5)],
-      ],
-      [Dimension.spin(), Dimension.polarization()],
-    )
-    const opCopy = op.copy()
-    expect(opCopy.toDense()).toEqual(op.toDense())
-    opCopy.entries[0].value.im = 999
-    expect(op.entries[0].value.im).toEqual(2)
-    opCopy.dimensionsOut[0].name = 'qqq'
-    expect(op.dimensionsOut[0].name).toEqual('spin')
-  })
-
   it('contract left and right', () => {
     const op = Operator.fromSparseCoordNames(
       [


### PR DESCRIPTION
Optimized some hot loops and removed a few unnecessary inefficiencies. Handrolling significantly speeds up tensor dot product and operator additions.

Dimensions equality is now optimized by in-constructor symbol lookup and direct symbol comparison at runtime. This makes `checkDimensions` not show up on flamegraphs at all.

This is mostly a stopgap solution, but we will need every drop of performance we can get once we start playing with animations in QG.