### PR TITLE
prevent vector mutation on propagation and make coords immutable

### DIFF
--- a/src/Frame.ts
+++ b/src/Frame.ts
@@ -202,19 +202,29 @@ export default class Frame {
       }
     }
 
-    _.range(this.nPhotons).forEach((i) => {
+    const { sizeX, sizeY, nPhotons } = this
+    let newEntries = [...this.vector.entries]
+
+    for (let i = 0; i < nPhotons; i++) {
       const [iX, iY, iDir] = this.vectorPosDirIndicesForParticle(i)
-      this.vector.entries.forEach((entry) => {
-        const dir = entry.coord[iDir]
-        entry.coord[iX] += dirToShiftX(dir)
-        entry.coord[iY] += dirToShiftY(dir)
-      })
-      this.vector.entries = this.vector.entries.filter((entry) => {
-        const x = entry.coord[iX]
-        const y = entry.coord[iY]
-        return 0 <= x && x < this.sizeX && 0 <= y && y < this.sizeY
-      })
-    })
+      newEntries = newEntries
+        .map((entry) => {
+          const dir = entry.coord[iDir]
+          const x = entry.coord[iX] + dirToShiftX(dir)
+          const y = entry.coord[iY] + dirToShiftY(dir)
+          const newCoords = entry.coord.slice()
+          newCoords[iX] = x
+          newCoords[iY] = y
+          return new VectorEntry(newCoords, entry.value)
+        })
+        .filter((entry) => {
+          const x = entry.coord[iX]
+          const y = entry.coord[iY]
+          return 0 <= x && x < sizeX && 0 <= y && y < sizeY
+        })
+    }
+
+    this.vector = new Vector(newEntries, this.vector.dimensions)
     return this
   }
 

--- a/src/Operator.ts
+++ b/src/Operator.ts
@@ -279,7 +279,7 @@ export default class Operator {
    *
    * @returns M_(coord_indices) ⊗ I_(everywhere_else) v
    */
-  mulVecPartial(coordIndices: number[], v: Vector): Vector {
+  mulVecPartial(coordIndices: readonly number[], v: Vector): Vector {
     const complementIndices = indicesComplement(coordIndices, v.dimensions.length)
     const joinCoords = joinCoordsFunc(coordIndices, complementIndices)
 

--- a/src/OperatorEntry.ts
+++ b/src/OperatorEntry.ts
@@ -6,8 +6,8 @@ import { coordsFromIndex } from './helpers'
  * To be used only within a Operator object, or to create such.
  */
 export default class OperatorEntry {
-  readonly coordOut: number[]
-  readonly coordIn: number[]
+  readonly coordOut: readonly number[]
+  readonly coordIn: readonly number[]
   readonly value: Complex
 
   /**
@@ -16,7 +16,7 @@ export default class OperatorEntry {
    * @param coordIn
    * @param value
    */
-  constructor(coordOut: number[], coordIn: number[], value: Complex) {
+  constructor(coordOut: readonly number[], coordIn: readonly number[], value: Complex) {
     this.coordOut = coordOut
     this.coordIn = coordIn
     this.value = value

--- a/src/Photons.ts
+++ b/src/Photons.ts
@@ -6,6 +6,7 @@ import Operator from './Operator'
 import Dimension from './Dimension'
 import { polStates } from './Ops'
 import Complex, { Cx } from './Complex'
+import VectorEntry from './VectorEntry'
 
 /**
  * Photons class.
@@ -249,19 +250,29 @@ export default class Photons {
       }
     }
 
-    _.range(this.nPhotons).forEach((i) => {
+    const { sizeX, sizeY, nPhotons } = this
+    let newEntries = [...this.vector.entries]
+
+    for (let i = 0; i < nPhotons; i++) {
       const [iX, iY, iDir] = this.vectorPosDirIndicesForParticle(i)
-      this.vector.entries.forEach((entry) => {
-        const dir = entry.coord[iDir]
-        entry.coord[iX] += dirToShiftX(dir)
-        entry.coord[iY] += dirToShiftY(dir)
-      })
-      this.vector.entries = this.vector.entries.filter((entry) => {
-        const x = entry.coord[iX]
-        const y = entry.coord[iY]
-        return 0 <= x && x < this.sizeX && 0 <= y && y < this.sizeY
-      })
-    })
+      newEntries = newEntries
+        .map((entry) => {
+          const dir = entry.coord[iDir]
+          const x = entry.coord[iX] + dirToShiftX(dir)
+          const y = entry.coord[iY] + dirToShiftY(dir)
+          const newCoords = entry.coord.slice()
+          newCoords[iX] = x
+          newCoords[iY] = y
+          return new VectorEntry(newCoords, entry.value)
+        })
+        .filter((entry) => {
+          const x = entry.coord[iX]
+          const y = entry.coord[iY]
+          return 0 <= x && x < sizeX && 0 <= y && y < sizeY
+        })
+    }
+
+    this.vector = new Vector(newEntries, this.vector.dimensions)
     return this
   }
 
@@ -312,7 +323,7 @@ export default class Photons {
    * FIXME: No return type
    */
   /* eslint-disable-next-line */
-  vectorValuedMeasurement(op: IXYOperator, photonId = 0): any {
+  vectorValuedMeasurement(op: IXYOperator, photonId = 0) {
     // as I see later, localizedOperator can be discarded as
     // we use localizedId anyway
     const localizedOperator = Photons.localizeOperator(this.sizeX, this.sizeY, op)

--- a/src/Vector.ts
+++ b/src/Vector.ts
@@ -14,8 +14,8 @@ import { IColumnOrRow, IEntryIndexValue, IKetComponent } from './interfaces'
  * @see {@link Complex} and {@link Dimension}
  */
 export default class Vector {
-  entries: VectorEntry[]
-  dimensions: Dimension[]
+  readonly entries: VectorEntry[]
+  readonly dimensions: Dimension[]
 
   /**
    * Creates a vector entry.
@@ -246,7 +246,7 @@ export default class Vector {
    * Mostly for intrnal use, e.g. partial inner product, Schmidt decomposition, etc.
    * @param coordIndices Sorted indices of dimensions for vectors. Complementary ones are used for grouping.
    */
-  toGroupedByCoords(coordIndices: number[]): IColumnOrRow[] {
+  toGroupedByCoords(coordIndices: readonly number[]): IColumnOrRow[] {
     const complementIndices = indicesComplement(coordIndices, this.dimensions.length)
     const contractionDimensions = _.at(this.dimensions, coordIndices)
 

--- a/src/VectorEntry.ts
+++ b/src/VectorEntry.ts
@@ -6,15 +6,15 @@ import { coordsFromIndex } from './helpers'
  * To be used only within a Vector object, or to create such.
  */
 export default class VectorEntry {
-  coord: number[]
-  value: Complex
+  readonly coord: readonly number[]
+  readonly value: Complex
 
   /**
    * Creates a VectorEntry from coord and value.
    * @param coord
    * @param value
    */
-  constructor(coord: number[], value: Complex) {
+  constructor(coord: readonly number[], value: Complex) {
     this.coord = coord
     this.value = value
   }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -32,7 +32,7 @@ export function coordsFromIndex(index: number, sizes: number[]): number[] {
  *
  * @return Index
  */
-export function coordsToIndex(coords: number[], sizes: number[]): number {
+export function coordsToIndex(coords: readonly number[], sizes: readonly number[]): number {
   if (coords.length !== sizes.length) {
     throw new Error(`Coordinates ${coords} and sizes ${sizes} are of different lengths}.`)
   }
@@ -54,7 +54,7 @@ export function coordsToIndex(coords: number[], sizes: number[]): number {
  * @param sizes  [s1, s2, ...] Dimensions sizes
  * @returns Error when not [0 <= c1 < s1, 0 <= c2 < s2, ...]
  */
-export function checkCoordsSizesCompability(coords: number[], sizes: number[]): void {
+export function checkCoordsSizesCompability(coords: readonly number[], sizes: readonly number[]): void {
   if (coords.length !== sizes.length) {
     throw new Error(`Coordinates [${coords}] incompatible with sizes [${sizes}].`)
   }
@@ -87,7 +87,7 @@ export function isPermutation(array: number[], n = array.length): boolean {
  * @param n E.g. 5
  * @return E.g. [0, 2, 4]
  */
-export function indicesComplement(indices: number[], n: number): number[] {
+export function indicesComplement(indices: readonly number[], n: number): number[] {
   const res = _.range(n).filter((i) => !_.includes(indices, i))
   if (!isPermutation(indices.concat(res))) {
     throw new Error(`In [${indices}] are not unique integer, between 0 and ${n - 1}.`)
@@ -101,8 +101,8 @@ export function indicesComplement(indices: number[], n: number): number[] {
  * @param complementIndices E.g. [0, 2, 4]
  * @returns A function that for [2, 3, 5], [7, 11] -> [2, 11, 3, 7, 5]
  */
-export function joinCoordsFunc(coordIndices: number[], complementIndices: number[]) {
-  return (coordGroup: number[], coordContraction: number[]): number[] => {
+export function joinCoordsFunc(coordIndices: readonly number[], complementIndices: readonly number[]) {
+  return (coordGroup: readonly number[], coordContraction: readonly number[]): number[] => {
     const coord = new Array(coordIndices.length + complementIndices.length)
     coordGroup.forEach((c, i) => {
       coord[complementIndices[i]] = c

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,7 +31,7 @@ export interface IPolarization {
  * For turning Operator in a sparse array of rows of columns
  */
 export interface IColumnOrRow {
-  coord: number[]
+  coord: readonly number[]
   vector: Vector
 }
 


### PR DESCRIPTION
The optimized propagation step currently is directly mutating the vector entry coords. Because we avoid copying vector structure between frames (`nextFrame` creates `new Frame` with previous frame's vector), the propagation was also influencing previous frame up until the `interact` step (which does create a new vector). That resulted in all coords throughout the simulation being shifted one step too far in the photon direction.

The change rewrites the code to not mutate existing structures, but instead create new `VectorEntry` objects. It also prevents similar bugs in the future by making the coord arrays and vectors internally readonly.