### PR TITLE
Partial measurement

### DIFF
--- a/src/Frame.ts
+++ b/src/Frame.ts
@@ -137,7 +137,7 @@ export default class Frame {
           `Old photon:\n${this.vector}\nand new photon:\n${newPhoton}`
         )
       }
-      this.vector = Vector.add([oldPhotons.outer(newPhoton), newPhoton.outer(oldPhotons)]).mulConstant(Cx(Math.SQRT1_2))
+      this.vector = Vector.add([oldPhotons.outer(newPhoton), newPhoton.outer(oldPhotons)]).mulByReal(Math.SQRT1_2)
     } else {
       throw `Adding 3 or more particles not yet implemented. We already have: ${this.nPhotons} photons.`
     }

--- a/src/IncoherentLight.ts
+++ b/src/IncoherentLight.ts
@@ -83,7 +83,7 @@ export default class IncoherentLight {
    * @returns Itself, for chaining.
    */
   normalize(): IncoherentLight {
-    this.vector = this.vector.mulConstant(Cx(1 / this.totalIntensity))
+    this.vector = this.vector.mulByReal(1 / this.totalIntensity)
     return this
   }
 

--- a/src/Measurement.ts
+++ b/src/Measurement.ts
@@ -1,8 +1,8 @@
 import Vector from './Vector'
 import { Cx } from './Complex'
 
-interface INamedVector<T> {
-  name: T[]
+interface INamedVector {
+  name: string[]
   vector: Vector
 }
 
@@ -11,20 +11,20 @@ interface INamedVector<T> {
  * Results are labeled by names of types T.
  * Supports successive measurements, to deal with many particles.
  */
-export default class Measurement<T> {
-  states: INamedVector<T>[]
+export default class Measurement {
+  states: INamedVector[]
 
-  constructor(states: INamedVector<T>[]) {
+  constructor(states: INamedVector[]) {
     this.states = states
   }
 
   /**
    * Create measurement from a single state. Normalizes it.
    * @param vector Vector to start with.
-   * @param name Vector name.
+   * @param name An optional vector name.
    */
-  static fromVector<T>(vector: Vector, name: T[] = []): Measurement<T> {
-    return new Measurement<T>([{ name, vector: vector.normalize() }])
+  static fromVector(vector: Vector, name: string[] = []): Measurement {
+    return new Measurement([{ name, vector: vector.normalize() }])
   }
 
   /**
@@ -33,7 +33,7 @@ export default class Measurement<T> {
    * @param measurements An array of projections.
    * @returns An array of projected states. Their norm squared is the probability.
    */
-  projectiveMeasurement(coordIndices: number[], projections: INamedVector<T>[]): Measurement<T> {
+  projectiveMeasurement(coordIndices: number[], projections: INamedVector[]): Measurement {
     const newStates = this.states.flatMap((state) => {
       return projections.map((projection) => ({
         name: [...state.name, ...projection.name],
@@ -47,7 +47,7 @@ export default class Measurement<T> {
       vector: vector.mulConstant(noDetectionAmplitude),
     }))
     const allStates = oldStates.concat(newStates).filter((state) => state.vector.normSquared() > 1e-8)
-    return new Measurement<T>(allStates)
+    return new Measurement(allStates)
   }
 
   /**
@@ -57,7 +57,8 @@ export default class Measurement<T> {
     return this.states
       .map((state) => {
         const percent = 100 * state.vector.normSquared()
-        return `${percent.toFixed(1)}%   ${state.vector.normalize().toKetString()}`
+        const name = state.name.join('&')
+        return `${percent.toFixed(1)}% [${name}] ${state.vector.normalize().toKetString()}`
       })
       .join('\n')
   }
@@ -65,7 +66,7 @@ export default class Measurement<T> {
   /**
    * Randomly selects outcome, according to probabilities.
    */
-  pickRandom(): Measurement<T> {
+  pickRandom(): Measurement {
     const probs = this.states.map((state) => state.vector.normSquared())
     const p = Math.random()
     let acc = 0

--- a/src/Measurement.ts
+++ b/src/Measurement.ts
@@ -1,12 +1,12 @@
 import Vector from './Vector'
 import Operator from './Operator'
 
-interface INamedVector {
+export interface INamedVector {
   name: string[]
   vector: Vector
 }
 
-interface INamedOperator {
+export interface INamedOperator {
   name: string[]
   operator: Operator
 }
@@ -36,6 +36,7 @@ export default class Measurement {
    * A projective, destructive measurement.
    * @param coordIndices Coordinates to be measured.
    * @param measurements An array of projections.
+   * @param povms An array of positive operators.
    * @returns An array of projected states. Their norm squared is the probability.
    */
   projectiveMeasurement(

--- a/src/Measurement.ts
+++ b/src/Measurement.ts
@@ -1,0 +1,81 @@
+import Vector from './Vector'
+import { Cx } from './Complex'
+
+interface INamedVector<T> {
+  name: T[]
+  vector: Vector
+}
+
+/**
+ * Class for performing measurements.
+ * Results are labeled by names of types T.
+ * Supports successive measurements, to deal with many particles.
+ */
+export default class Measurement<T> {
+  states: INamedVector<T>[]
+
+  constructor(states: INamedVector<T>[]) {
+    this.states = states
+  }
+
+  /**
+   * Create measurement from a single state. Normalizes it.
+   * @param vector Vector to start with.
+   * @param name Vector name.
+   */
+  static fromVector<T>(vector: Vector, name: T[] = []): Measurement<T> {
+    return new Measurement<T>([{ name, vector: vector.normalize() }])
+  }
+
+  /**
+   * A projective, destructive measurement.
+   * @param coordIndices Coordinates to be measured.
+   * @param measurements An array of projections.
+   * @returns An array of projected states. Their norm squared is the probability.
+   */
+  projectiveMeasurement(coordIndices: number[], projections: INamedVector<T>[]): Measurement<T> {
+    const newStates = this.states.flatMap((state) => {
+      return projections.map((projection) => ({
+        name: [...state.name, ...projection.name],
+        vector: projection.vector.innerPartial(coordIndices, state.vector),
+      }))
+    })
+    const detectionProbability = newStates.map((state) => state.vector.normSquared()).reduce((a, b) => a + b, 0)
+    const noDetectionAmplitude = Cx(Math.sqrt(1 - detectionProbability))
+    const oldStates = this.states.map(({ name, vector }) => ({
+      name,
+      vector: vector.mulConstant(noDetectionAmplitude),
+    }))
+    const allStates = oldStates.concat(newStates).filter((state) => state.vector.normSquared() > 1e-8)
+    return new Measurement<T>(allStates)
+  }
+
+  /**
+   * Print outcomes.
+   */
+  toString(): string {
+    return this.states
+      .map((state) => {
+        const percent = 100 * state.vector.normSquared()
+        return `${percent.toFixed(1)}%   ${state.vector.normalize().toKetString()}`
+      })
+      .join('\n')
+  }
+
+  /**
+   * Randomly selects outcome, according to probabilities.
+   */
+  pickRandom(): Measurement<T> {
+    const probs = this.states.map((state) => state.vector.normSquared())
+    const p = Math.random()
+    let acc = 0
+    for (let i = 0; i < this.states.length; i++) {
+      acc += probs[i]
+      if (acc > p) {
+        const { name, vector } = this.states[i]
+        return Measurement.fromVector(vector, name)
+      }
+    }
+    throw new Error('Measurement probabilities does not sum up to 1.')
+  }
+}

--- a/src/Operator.ts
+++ b/src/Operator.ts
@@ -1,5 +1,5 @@
 /* eslint-disable-next-line */
-import _ from 'lodash'
+import _, { entries } from 'lodash'
 import { coordsToIndex, checkCoordsSizesCompability, isPermutation, indicesComplement, joinCoordsFunc } from './helpers'
 import Complex, { Cx } from './Complex'
 import VectorEntry from './VectorEntry'
@@ -622,6 +622,21 @@ export default class Operator {
         ),
     )
     return new Operator(entries, dimensionsOut, dimensionsIn)
+  }
+
+  /**
+   * Turn vector into a (non-normalized) projection on it:
+   * |v⟩ -> |v⟩⟨v|
+   * @param v |v⟩
+   * @returns |v⟩⟨v|
+   */
+  static projectionOn(v: Vector): Operator {
+    const opEntries = v.entries.flatMap((entryOut) =>
+      v.entries.map(
+        (entryIn) => new OperatorEntry(entryOut.coord, entryIn.coord, entryOut.value.mul(entryIn.value.conj())),
+      ),
+    )
+    return new Operator(opEntries, [...v.dimensions])
   }
 
   /**

--- a/src/Photons.ts
+++ b/src/Photons.ts
@@ -196,6 +196,10 @@ export default class Photons {
     return Vector.indicator(dimensions, state).outer(polStates[pol])
   }
 
+  /**
+   * Generates a DirPol basis for completem projective, destructive measurement.
+   * @param factor Multiplicative factor. Use Math.SQRT1_2 for 50% of detection.
+   */
   static allDirectionsVec(factor = 1): INamedVector[] {
     const dirs = ['>', '^', '<', 'v']
     const pols = ['H', 'V']
@@ -207,6 +211,9 @@ export default class Photons {
     )
   }
 
+  /**
+   * Generates a DirPol projections for completem projective, non-destructive measurement.
+   */
   static allDirectionsOps(): INamedOperator[] {
     const dirs = ['>', '^', '<', 'v']
     const pols = ['H', 'V']
@@ -337,6 +344,14 @@ export default class Photons {
     return this
   }
 
+  /**
+   * @see {@link localizeOperator}
+   * @param sizeX
+   * @param sizeY
+   * @param x
+   * @param y
+   * @param vec
+   */
   static localizeVector(sizeX: number, sizeY: number, x: number, y: number, vec: Vector): Vector {
     const dimX = Dimension.position(sizeX, 'x')
     const dimY = Dimension.position(sizeY, 'y')
@@ -359,6 +374,9 @@ export default class Photons {
     return Operator.outer([Operator.indicator([dimX, dimY], [`${op.x}`, `${op.y}`]), op.op])
   }
 
+  /**
+   * Perform measurement given measurement projections and positive operators.
+   */
   measure(): Measurement {
     let ensamble = Measurement.fromVector(this.vector)
     for (let i = this.nPhotons - 1; i >= 0; i--) {

--- a/src/Photons.ts
+++ b/src/Photons.ts
@@ -179,7 +179,7 @@ export default class Photons {
           `Old photon:\n${this.vector}\nand new photon:\n${newPhoton}`
         )
       }
-      this.vector = Vector.add([oldPhotons.outer(newPhoton), newPhoton.outer(oldPhotons)]).mulConstant(Cx(Math.SQRT1_2))
+      this.vector = Vector.add([oldPhotons.outer(newPhoton), newPhoton.outer(oldPhotons)]).mulByReal(Math.SQRT1_2)
     } else {
       throw `Adding 3 or more particles not yet implemented. We already have: ${this.nPhotons} photons.`
     }

--- a/src/Photons.ts
+++ b/src/Photons.ts
@@ -196,6 +196,28 @@ export default class Photons {
     return Vector.indicator(dimensions, state).outer(polStates[pol])
   }
 
+  static allDirectionsVec(): INamedVector[] {
+    const dirs = ['>', '^', '<', 'v']
+    const pols = ['H', 'V']
+    return dirs.flatMap((dir) =>
+      pols.map((pol) => ({
+        name: [`${dir}${pol}`],
+        vector: Vector.indicator([Dimension.direction(), Dimension.polarization()], [dir, pol]),
+      })),
+    )
+  }
+
+  static allDirectionsOps(): INamedOperator[] {
+    const dirs = ['>', '^', '<', 'v']
+    const pols = ['H', 'V']
+    return dirs.flatMap((dir) =>
+      pols.map((pol) => ({
+        name: [`${dir}${pol}`],
+        operator: Operator.indicator([Dimension.direction(), Dimension.polarization()], [dir, pol]),
+      })),
+    )
+  }
+
   /**
    * Add one more photon to the state, using {@link Photons.vectorFromIndicator}.
    *
@@ -338,9 +360,13 @@ export default class Photons {
   }
 
   measure(): Measurement {
-    const ensamble = Measurement.fromVector(this.vector)
+    let ensamble = Measurement.fromVector(this.vector)
     for (let i = this.nPhotons - 1; i >= 0; i--) {
-      ensamble.projectiveMeasurement(this.vectorIndicesForParticle(i), this.measurementVecs, this.measurementOps)
+      ensamble = ensamble.projectiveMeasurement(
+        this.vectorIndicesForParticle(0),
+        this.measurementVecs,
+        this.measurementOps,
+      )
     }
     return ensamble
   }

--- a/src/Photons.ts
+++ b/src/Photons.ts
@@ -196,13 +196,13 @@ export default class Photons {
     return Vector.indicator(dimensions, state).outer(polStates[pol])
   }
 
-  static allDirectionsVec(): INamedVector[] {
+  static allDirectionsVec(factor = 1): INamedVector[] {
     const dirs = ['>', '^', '<', 'v']
     const pols = ['H', 'V']
     return dirs.flatMap((dir) =>
       pols.map((pol) => ({
         name: [`${dir}${pol}`],
-        vector: Vector.indicator([Dimension.direction(), Dimension.polarization()], [dir, pol]),
+        vector: Vector.indicator([Dimension.direction(), Dimension.polarization()], [dir, pol]).mulByReal(factor),
       })),
     )
   }

--- a/src/Vector.ts
+++ b/src/Vector.ts
@@ -326,6 +326,15 @@ export default class Vector {
   }
 
   /**
+   * Is it close to zero?
+   * @param eps Euclidean distance tolerance.
+   * @return Checks v ~= 0
+   */
+  isCloseToZero(eps = 1e-6): boolean {
+    return Math.sqrt(this.normSquared()) < eps
+  }
+
+  /**
    * Change all dimensions with a given dimName to the desired basis.
    * @see {@link Basis.fromString} and {@link changeAllDimsOfVector}
    * @param dimName 'polarization', 'spin' or 'qubit'

--- a/src/Vector.ts
+++ b/src/Vector.ts
@@ -140,6 +140,15 @@ export default class Vector {
   }
 
   /**
+   * Multiplies vector by a real number.
+   * @param x A factor.
+   * @returns x v
+   */
+  mulByReal(x: number): Vector {
+    return this.mulConstant(Cx(x))
+  }
+
+  /**
    * Adds to vectors.
    * @param v2 The other vector.
    *

--- a/tests/Measurement.test.ts
+++ b/tests/Measurement.test.ts
@@ -13,15 +13,15 @@ describe('Measurement', () => {
       ],
       [Dimension.qubit()],
     ).normalize()
-    const m = new Measurement<string>([{ name: [], vector }])
+    const m = new Measurement([{ name: [], vector }])
     expect(m.states.length).toBe(1)
-    expect(m.toString()).toBe('100.0%   0.71 exp(0.00τi) |0⟩ + 0.71 exp(0.00τi) |1⟩')
+    expect(m.toString()).toBe('100.0% [] 0.71 exp(0.00τi) |0⟩ + 0.71 exp(0.00τi) |1⟩')
     const projections = [
       { name: ['zero'], vector: Vector.indicator([Dimension.qubit()], '0') },
       { name: ['one'], vector: Vector.indicator([Dimension.qubit()], '1') },
     ]
     const newM = m.projectiveMeasurement([0], projections)
-    expect(newM.toString()).toBe(['50.0%   1.00 exp(0.00τi) |⟩', '50.0%   1.00 exp(0.00τi) |⟩'].join('\n'))
+    expect(newM.toString()).toBe(['50.0% [zero] 1.00 exp(0.00τi) |⟩', '50.0% [one] 1.00 exp(0.00τi) |⟩'].join('\n'))
   })
 
   it('two particles', () => {
@@ -32,16 +32,20 @@ describe('Measurement', () => {
       ],
       [Dimension.qubit(), Dimension.qubit()],
     ).normalize()
-    const m = new Measurement<string>([{ name: [], vector }])
+    const m = new Measurement([{ name: [], vector }])
     const projections = [
       { name: ['zero'], vector: Vector.indicator([Dimension.qubit()], '0') },
       { name: ['one'], vector: Vector.indicator([Dimension.qubit()], '1') },
     ]
     const measFirst = m.projectiveMeasurement([0], projections)
-    expect(measFirst.toString()).toBe(['50.0%   1.00 exp(0.00τi) |1⟩', '50.0%   1.00 exp(0.50τi) |0⟩'].join('\n'))
+    expect(measFirst.toString()).toBe(
+      ['50.0% [zero] 1.00 exp(0.00τi) |1⟩', '50.0% [one] 1.00 exp(0.50τi) |0⟩'].join('\n'),
+    )
 
     const measLast = m.projectiveMeasurement([1], projections)
-    expect(measLast.toString()).toBe(['50.0%   1.00 exp(0.50τi) |1⟩', '50.0%   1.00 exp(0.00τi) |0⟩'].join('\n'))
+    expect(measLast.toString()).toBe(
+      ['50.0% [zero] 1.00 exp(0.50τi) |1⟩', '50.0% [one] 1.00 exp(0.00τi) |0⟩'].join('\n'),
+    )
   })
 
   it('non-complete projection', () => {
@@ -52,14 +56,14 @@ describe('Measurement', () => {
       ],
       [Dimension.qubit(), Dimension.qubit(), Dimension.polarization()],
     ).normalize()
-    const m = new Measurement<string>([{ name: [], vector }])
+    const m = new Measurement([{ name: [], vector }])
     const projections = [
       { name: ['0', '0'], vector: Vector.indicator([Dimension.qubit(), Dimension.qubit()], ['0', '0']) },
       { name: ['0', '1'], vector: Vector.indicator([Dimension.qubit(), Dimension.qubit()], ['0', '1']) },
     ]
     const measured = m.projectiveMeasurement([0, 1], projections)
     expect(measured.toString()).toBe(
-      ['50.0%   0.71 exp(0.00τi) |0,1,H⟩ + 0.71 exp(0.50τi) |1,0,V⟩', '50.0%   1.00 exp(0.00τi) |H⟩'].join('\n'),
+      ['50.0% [] 0.71 exp(0.00τi) |0,1,H⟩ + 0.71 exp(0.50τi) |1,0,V⟩', '50.0% [0&1] 1.00 exp(0.00τi) |H⟩'].join('\n'),
     )
   })
 
@@ -73,11 +77,11 @@ describe('Measurement', () => {
       ],
       [Dimension.spin(), Dimension.polarization(), Dimension.position(3)],
     )
-    const m = new Measurement<string>([{ name: [], vector }])
+    const m = new Measurement([{ name: [], vector }])
     expect(m.states.length).toBe(1)
     expect(m.toString()).toBe(
       // eslint-disable-next-line max-len
-      '100.0%   0.50 exp(0.75τi) |u,V,2⟩ + 0.50 exp(0.00τi) |d,H,0⟩ + 0.50 exp(0.50τi) |d,V,1⟩ + 0.50 exp(0.25τi) |d,V,2⟩',
+      '100.0% [] 0.50 exp(0.75τi) |u,V,2⟩ + 0.50 exp(0.00τi) |d,H,0⟩ + 0.50 exp(0.50τi) |d,V,1⟩ + 0.50 exp(0.25τi) |d,V,2⟩',
     )
     const projections = [
       { name: ['H'], vector: Vector.indicator([Dimension.polarization()], 'H') },
@@ -93,8 +97,8 @@ describe('Measurement', () => {
     )
     expect(newM.toString()).toBe(
       [
-        '25.0%   1.00 exp(0.00τi) |d,0⟩',
-        '75.0%   0.58 exp(0.75τi) |u,2⟩ + 0.58 exp(0.50τi) |d,1⟩ + 0.58 exp(0.25τi) |d,2⟩',
+        '25.0% [H] 1.00 exp(0.00τi) |d,0⟩',
+        '75.0% [V] 0.58 exp(0.75τi) |u,2⟩ + 0.58 exp(0.50τi) |d,1⟩ + 0.58 exp(0.25τi) |d,2⟩',
       ].join('\n'),
     )
   })
@@ -109,7 +113,7 @@ describe('Measurement', () => {
       ],
       [Dimension.spin(), Dimension.polarization(), Dimension.position(3)],
     )
-    const m = new Measurement<string>([{ name: [], vector }])
+    const m = new Measurement([{ name: [], vector }])
     const projectionsOne = [
       { name: ['0'], vector: Vector.indicator([Dimension.position(3)], '0') },
       { name: ['2'], vector: Vector.indicator([Dimension.position(3)], '2') },
@@ -122,9 +126,9 @@ describe('Measurement', () => {
     expect(stepOne.toString()).toBe(
       [
         // eslint-disable-next-line max-len
-        '25.0%   0.50 exp(0.75τi) |u,V,2⟩ + 0.50 exp(0.00τi) |d,H,0⟩ + 0.50 exp(0.50τi) |d,V,1⟩ + 0.50 exp(0.25τi) |d,V,2⟩',
-        '25.0%   1.00 exp(0.00τi) |d,H⟩',
-        '50.0%   0.71 exp(0.75τi) |u,V⟩ + 0.71 exp(0.25τi) |d,V⟩',
+        '25.0% [] 0.50 exp(0.75τi) |u,V,2⟩ + 0.50 exp(0.00τi) |d,H,0⟩ + 0.50 exp(0.50τi) |d,V,1⟩ + 0.50 exp(0.25τi) |d,V,2⟩',
+        '25.0% [0] 1.00 exp(0.00τi) |d,H⟩',
+        '50.0% [2] 0.71 exp(0.75τi) |u,V⟩ + 0.71 exp(0.25τi) |d,V⟩',
       ].join('\n'),
     )
     // crucial remark: as the number of dimensions changes, we need to apply operations in reverse order,
@@ -133,13 +137,13 @@ describe('Measurement', () => {
     expect(stepTwo.toString()).toBe(
       [
         // eslint-disable-next-line max-len
-        '8.6%   0.50 exp(0.75τi) |u,V,2⟩ + 0.50 exp(0.00τi) |d,H,0⟩ + 0.50 exp(0.50τi) |d,V,1⟩ + 0.50 exp(0.25τi) |d,V,2⟩',
-        '8.6%   1.00 exp(0.00τi) |d,H⟩',
-        '17.2%   0.71 exp(0.75τi) |u,V⟩ + 0.71 exp(0.25τi) |d,V⟩',
-        '6.3%   1.00 exp(0.00τi) |d,0⟩',
-        '9.4%   0.58 exp(0.75τi) |u,2⟩ + 0.58 exp(0.50τi) |d,1⟩ + 0.58 exp(0.25τi) |d,2⟩',
-        '25.0%   1.00 exp(0.00τi) |d⟩',
-        '25.0%   0.71 exp(0.75τi) |u⟩ + 0.71 exp(0.25τi) |d⟩',
+        '8.6% [] 0.50 exp(0.75τi) |u,V,2⟩ + 0.50 exp(0.00τi) |d,H,0⟩ + 0.50 exp(0.50τi) |d,V,1⟩ + 0.50 exp(0.25τi) |d,V,2⟩',
+        '8.6% [0] 1.00 exp(0.00τi) |d,H⟩',
+        '17.2% [2] 0.71 exp(0.75τi) |u,V⟩ + 0.71 exp(0.25τi) |d,V⟩',
+        '6.3% [H] 1.00 exp(0.00τi) |d,0⟩',
+        '9.4% [V] 0.58 exp(0.75τi) |u,2⟩ + 0.58 exp(0.50τi) |d,1⟩ + 0.58 exp(0.25τi) |d,2⟩',
+        '25.0% [0&H] 1.00 exp(0.00τi) |d⟩',
+        '25.0% [2&V] 0.71 exp(0.75τi) |u⟩ + 0.71 exp(0.25τi) |d⟩',
       ].join('\n'),
     )
   })

--- a/tests/Measurement.test.ts
+++ b/tests/Measurement.test.ts
@@ -3,6 +3,7 @@ import Vector from '../src/Vector'
 import Dimension from '../src/Dimension'
 import { Cx } from '../src/Complex'
 import './customMatchers'
+import Operator from '../src/Operator'
 
 describe('Measurement', () => {
   it('the simplest measurement', () => {
@@ -163,6 +164,78 @@ describe('Measurement', () => {
         '12.5% [V] 1.00 exp(0.50τi) |d,1⟩',
         '25.0% [0&H] 1.00 exp(0.00τi) |d⟩',
         '25.0% [2&V] 0.71 exp(0.75τi) |u⟩ + 0.71 exp(0.25τi) |d⟩',
+      ].join('\n'),
+    )
+  })
+
+  it('POVM measurement all', () => {
+    const vector = Vector.fromSparseCoordNames(
+      [
+        ['01H', Cx(1)],
+        ['10V', Cx(-1)],
+      ],
+      [Dimension.qubit(), Dimension.qubit(), Dimension.polarization()],
+    ).normalize()
+    const m = new Measurement([{ name: [], vector }])
+    const povms = [
+      { name: ['H'], operator: Operator.indicator([Dimension.polarization()], 'H') },
+      { name: ['V'], operator: Operator.indicator([Dimension.polarization()], 'V') },
+    ]
+    const measured = m.projectiveMeasurement([2], [], povms)
+    expect(measured.toString()).toBe(
+      ['50.0% [H] 1.00 exp(0.00τi) |0,1,H⟩', '50.0% [V] 1.00 exp(0.50τi) |1,0,V⟩'].join('\n'),
+    )
+  })
+  it('POVM measurement part', () => {
+    const vector = Vector.fromSparseCoordNames(
+      [
+        ['01H', Cx(1)],
+        ['10V', Cx(-1)],
+      ],
+      [Dimension.qubit(), Dimension.qubit(), Dimension.polarization()],
+    ).normalize()
+    const m = new Measurement([{ name: [], vector }])
+    const povms = [
+      { name: ['H'], operator: Operator.indicator([Dimension.polarization()], 'H').mulConstant(Cx(0.5)) },
+      { name: ['V'], operator: Operator.indicator([Dimension.polarization()], 'V') },
+    ]
+    const measured = m.projectiveMeasurement([2], [], povms)
+    expect(measured.toString()).toBe(
+      [
+        '25.0% [] 1.00 exp(0.00τi) |0,1,H⟩',
+        '25.0% [H] 1.00 exp(0.00τi) |0,1,H⟩',
+        '50.0% [V] 1.00 exp(0.50τi) |1,0,V⟩',
+      ].join('\n'),
+    )
+  })
+
+  it('Projective + POVM measurement', () => {
+    const vector = Vector.fromSparseCoordNames(
+      [
+        ['dH0', Cx(0.5)],
+        ['dV1', Cx(-0.5)],
+        ['dV2', Cx(0, 0.5)],
+        ['uV2', Cx(0, -0.5)],
+      ],
+      [Dimension.spin(), Dimension.polarization(), Dimension.position(3)],
+    )
+    const m = new Measurement([{ name: [], vector }])
+    const projections = [
+      { name: ['0'], vector: Vector.indicator([Dimension.position(3)], '0') },
+      { name: ['1'], vector: Vector.indicator([Dimension.position(3)], '1').mulByReal(Math.SQRT1_2) },
+    ]
+    const povms = [
+      { name: ['1nondest'], operator: Operator.indicator([Dimension.position(3)], '1').mulConstant(Cx(0.5)) },
+      { name: ['2nondest'], operator: Operator.indicator([Dimension.position(3)], '2').mulConstant(Cx(0.25)) },
+    ]
+    const measured = m.projectiveMeasurement([2], projections, povms)
+    expect(measured.toString()).toBe(
+      [
+        '37.5% [] 0.71 exp(0.75τi) |u,V,2⟩ + 0.71 exp(0.25τi) |d,V,2⟩',
+        '25.0% [0] 1.00 exp(0.00τi) |d,H⟩',
+        '12.5% [1] 1.00 exp(0.50τi) |d,V⟩',
+        '12.5% [1nondest] 1.00 exp(0.50τi) |d,V,1⟩',
+        '12.5% [2nondest] 0.71 exp(0.75τi) |u,V,2⟩ + 0.71 exp(0.25τi) |d,V,2⟩',
       ].join('\n'),
     )
   })

--- a/tests/Measurement.test.ts
+++ b/tests/Measurement.test.ts
@@ -1,0 +1,146 @@
+import Measurement from '../src/Measurement'
+import Vector from '../src/Vector'
+import Dimension from '../src/Dimension'
+import { Cx } from '../src/Complex'
+import './customMatchers'
+
+describe('Measurement', () => {
+  it('the simplest measurement', () => {
+    const vector = Vector.fromSparseCoordNames(
+      [
+        ['0', Cx(1)],
+        ['1', Cx(1)],
+      ],
+      [Dimension.qubit()],
+    ).normalize()
+    const m = new Measurement<string>([{ name: [], vector }])
+    expect(m.states.length).toBe(1)
+    expect(m.toString()).toBe('100.0%   0.71 exp(0.00τi) |0⟩ + 0.71 exp(0.00τi) |1⟩')
+    const projections = [
+      { name: ['zero'], vector: Vector.indicator([Dimension.qubit()], '0') },
+      { name: ['one'], vector: Vector.indicator([Dimension.qubit()], '1') },
+    ]
+    const newM = m.projectiveMeasurement([0], projections)
+    expect(newM.toString()).toBe(['50.0%   1.00 exp(0.00τi) |⟩', '50.0%   1.00 exp(0.00τi) |⟩'].join('\n'))
+  })
+
+  it('two particles', () => {
+    const vector = Vector.fromSparseCoordNames(
+      [
+        ['01', Cx(1)],
+        ['10', Cx(-1)],
+      ],
+      [Dimension.qubit(), Dimension.qubit()],
+    ).normalize()
+    const m = new Measurement<string>([{ name: [], vector }])
+    const projections = [
+      { name: ['zero'], vector: Vector.indicator([Dimension.qubit()], '0') },
+      { name: ['one'], vector: Vector.indicator([Dimension.qubit()], '1') },
+    ]
+    const measFirst = m.projectiveMeasurement([0], projections)
+    expect(measFirst.toString()).toBe(['50.0%   1.00 exp(0.00τi) |1⟩', '50.0%   1.00 exp(0.50τi) |0⟩'].join('\n'))
+
+    const measLast = m.projectiveMeasurement([1], projections)
+    expect(measLast.toString()).toBe(['50.0%   1.00 exp(0.50τi) |1⟩', '50.0%   1.00 exp(0.00τi) |0⟩'].join('\n'))
+  })
+
+  it('non-complete projection', () => {
+    const vector = Vector.fromSparseCoordNames(
+      [
+        ['01H', Cx(1)],
+        ['10V', Cx(-1)],
+      ],
+      [Dimension.qubit(), Dimension.qubit(), Dimension.polarization()],
+    ).normalize()
+    const m = new Measurement<string>([{ name: [], vector }])
+    const projections = [
+      { name: ['0', '0'], vector: Vector.indicator([Dimension.qubit(), Dimension.qubit()], ['0', '0']) },
+      { name: ['0', '1'], vector: Vector.indicator([Dimension.qubit(), Dimension.qubit()], ['0', '1']) },
+    ]
+    const measured = m.projectiveMeasurement([0, 1], projections)
+    expect(measured.toString()).toBe(
+      ['50.0%   0.71 exp(0.00τi) |0,1,H⟩ + 0.71 exp(0.50τi) |1,0,V⟩', '50.0%   1.00 exp(0.00τi) |H⟩'].join('\n'),
+    )
+  })
+
+  it('more advanced measurement', () => {
+    const vector = Vector.fromSparseCoordNames(
+      [
+        ['dH0', Cx(0.5)],
+        ['dV1', Cx(-0.5)],
+        ['dV2', Cx(0, 0.5)],
+        ['uV2', Cx(0, -0.5)],
+      ],
+      [Dimension.spin(), Dimension.polarization(), Dimension.position(3)],
+    )
+    const m = new Measurement<string>([{ name: [], vector }])
+    expect(m.states.length).toBe(1)
+    expect(m.toString()).toBe(
+      // eslint-disable-next-line max-len
+      '100.0%   0.50 exp(0.75τi) |u,V,2⟩ + 0.50 exp(0.00τi) |d,H,0⟩ + 0.50 exp(0.50τi) |d,V,1⟩ + 0.50 exp(0.25τi) |d,V,2⟩',
+    )
+    const projections = [
+      { name: ['H'], vector: Vector.indicator([Dimension.polarization()], 'H') },
+      { name: ['V'], vector: Vector.indicator([Dimension.polarization()], 'V') },
+    ]
+    const newM = m.projectiveMeasurement([1], projections)
+    expect(newM.states.length).toBe(2)
+    expect(newM.states[0].name).toEqual(['H'])
+    expect(newM.states[0].vector.toKetString('cartesian')).toEqual('(0.50 +0.00i) |d,0⟩')
+    expect(newM.states[1].name).toEqual(['V'])
+    expect(newM.states[1].vector.toKetString('cartesian')).toEqual(
+      '(0.00 -0.50i) |u,2⟩ + (-0.50 +0.00i) |d,1⟩ + (0.00 +0.50i) |d,2⟩',
+    )
+    expect(newM.toString()).toBe(
+      [
+        '25.0%   1.00 exp(0.00τi) |d,0⟩',
+        '75.0%   0.58 exp(0.75τi) |u,2⟩ + 0.58 exp(0.50τi) |d,1⟩ + 0.58 exp(0.25τi) |d,2⟩',
+      ].join('\n'),
+    )
+  })
+
+  it('cascade partial measurement', () => {
+    const vector = Vector.fromSparseCoordNames(
+      [
+        ['dH0', Cx(0.5)],
+        ['dV1', Cx(-0.5)],
+        ['dV2', Cx(0, 0.5)],
+        ['uV2', Cx(0, -0.5)],
+      ],
+      [Dimension.spin(), Dimension.polarization(), Dimension.position(3)],
+    )
+    const m = new Measurement<string>([{ name: [], vector }])
+    const projectionsOne = [
+      { name: ['0'], vector: Vector.indicator([Dimension.position(3)], '0') },
+      { name: ['2'], vector: Vector.indicator([Dimension.position(3)], '2') },
+    ]
+    const projectionsTwo = [
+      { name: ['H'], vector: Vector.indicator([Dimension.polarization()], 'H') },
+      { name: ['V'], vector: Vector.indicator([Dimension.polarization()], 'V').mulConstant(Cx(Math.SQRT1_2)) },
+    ]
+    const stepOne = m.projectiveMeasurement([2], projectionsOne)
+    expect(stepOne.toString()).toBe(
+      [
+        // eslint-disable-next-line max-len
+        '25.0%   0.50 exp(0.75τi) |u,V,2⟩ + 0.50 exp(0.00τi) |d,H,0⟩ + 0.50 exp(0.50τi) |d,V,1⟩ + 0.50 exp(0.25τi) |d,V,2⟩',
+        '25.0%   1.00 exp(0.00τi) |d,H⟩',
+        '50.0%   0.71 exp(0.75τi) |u,V⟩ + 0.71 exp(0.25τi) |d,V⟩',
+      ].join('\n'),
+    )
+    // crucial remark: as the number of dimensions changes, we need to apply operations in reverse order,
+    // i.e. starting from the last dimension/particle
+    const stepTwo = stepOne.projectiveMeasurement([1], projectionsTwo)
+    expect(stepTwo.toString()).toBe(
+      [
+        // eslint-disable-next-line max-len
+        '8.6%   0.50 exp(0.75τi) |u,V,2⟩ + 0.50 exp(0.00τi) |d,H,0⟩ + 0.50 exp(0.50τi) |d,V,1⟩ + 0.50 exp(0.25τi) |d,V,2⟩',
+        '8.6%   1.00 exp(0.00τi) |d,H⟩',
+        '17.2%   0.71 exp(0.75τi) |u,V⟩ + 0.71 exp(0.25τi) |d,V⟩',
+        '6.3%   1.00 exp(0.00τi) |d,0⟩',
+        '9.4%   0.58 exp(0.75τi) |u,2⟩ + 0.58 exp(0.50τi) |d,1⟩ + 0.58 exp(0.25τi) |d,2⟩',
+        '25.0%   1.00 exp(0.00τi) |d⟩',
+        '25.0%   0.71 exp(0.75τi) |u⟩ + 0.71 exp(0.25τi) |d⟩',
+      ].join('\n'),
+    )
+  })
+})

--- a/tests/Measurement.test.ts
+++ b/tests/Measurement.test.ts
@@ -63,7 +63,30 @@ describe('Measurement', () => {
     ]
     const measured = m.projectiveMeasurement([0, 1], projections)
     expect(measured.toString()).toBe(
-      ['50.0% [] 0.71 exp(0.00τi) |0,1,H⟩ + 0.71 exp(0.50τi) |1,0,V⟩', '50.0% [0&1] 1.00 exp(0.00τi) |H⟩'].join('\n'),
+      ['50.0% [] 1.00 exp(0.50τi) |1,0,V⟩', '50.0% [0&1] 1.00 exp(0.00τi) |H⟩'].join('\n'),
+    )
+  })
+
+  it('probabilistic measurement', () => {
+    const vector = Vector.fromSparseCoordNames(
+      [
+        ['01H', Cx(1)],
+        ['10V', Cx(-1)],
+      ],
+      [Dimension.qubit(), Dimension.qubit(), Dimension.polarization()],
+    ).normalize()
+    const m = new Measurement([{ name: [], vector }])
+    const projections = [
+      { name: ['H'], vector: Vector.indicator([Dimension.polarization()], 'H').mulByReal(Math.SQRT1_2) },
+      { name: ['V'], vector: Vector.indicator([Dimension.polarization()], 'V').mulByReal(Math.SQRT1_2) },
+    ]
+    const measured = m.projectiveMeasurement([2], projections)
+    expect(measured.toString()).toBe(
+      [
+        '50.0% [] 0.71 exp(0.00τi) |0,1,H⟩ + 0.71 exp(0.50τi) |1,0,V⟩',
+        '25.0% [H] 1.00 exp(0.00τi) |0,1⟩',
+        '25.0% [V] 1.00 exp(0.50τi) |1,0⟩',
+      ].join('\n'),
     )
   })
 
@@ -120,13 +143,12 @@ describe('Measurement', () => {
     ]
     const projectionsTwo = [
       { name: ['H'], vector: Vector.indicator([Dimension.polarization()], 'H') },
-      { name: ['V'], vector: Vector.indicator([Dimension.polarization()], 'V').mulConstant(Cx(Math.SQRT1_2)) },
+      { name: ['V'], vector: Vector.indicator([Dimension.polarization()], 'V').mulByReal(Math.SQRT1_2) },
     ]
     const stepOne = m.projectiveMeasurement([2], projectionsOne)
     expect(stepOne.toString()).toBe(
       [
-        // eslint-disable-next-line max-len
-        '25.0% [] 0.50 exp(0.75τi) |u,V,2⟩ + 0.50 exp(0.00τi) |d,H,0⟩ + 0.50 exp(0.50τi) |d,V,1⟩ + 0.50 exp(0.25τi) |d,V,2⟩',
+        '25.0% [] 1.00 exp(0.50τi) |d,V,1⟩',
         '25.0% [0] 1.00 exp(0.00τi) |d,H⟩',
         '50.0% [2] 0.71 exp(0.75τi) |u,V⟩ + 0.71 exp(0.25τi) |d,V⟩',
       ].join('\n'),
@@ -136,12 +158,9 @@ describe('Measurement', () => {
     const stepTwo = stepOne.projectiveMeasurement([1], projectionsTwo)
     expect(stepTwo.toString()).toBe(
       [
-        // eslint-disable-next-line max-len
-        '8.6% [] 0.50 exp(0.75τi) |u,V,2⟩ + 0.50 exp(0.00τi) |d,H,0⟩ + 0.50 exp(0.50τi) |d,V,1⟩ + 0.50 exp(0.25τi) |d,V,2⟩',
-        '8.6% [0] 1.00 exp(0.00τi) |d,H⟩',
-        '17.2% [2] 0.71 exp(0.75τi) |u,V⟩ + 0.71 exp(0.25τi) |d,V⟩',
-        '6.3% [H] 1.00 exp(0.00τi) |d,0⟩',
-        '9.4% [V] 0.58 exp(0.75τi) |u,2⟩ + 0.58 exp(0.50τi) |d,1⟩ + 0.58 exp(0.25τi) |d,2⟩',
+        '12.5% [] 1.00 exp(0.50τi) |d,V,1⟩',
+        '25.0% [2] 0.71 exp(0.75τi) |u,V⟩ + 0.71 exp(0.25τi) |d,V⟩',
+        '12.5% [V] 1.00 exp(0.50τi) |d,1⟩',
         '25.0% [0&H] 1.00 exp(0.00τi) |d⟩',
         '25.0% [2&V] 0.71 exp(0.75τi) |u⟩ + 0.71 exp(0.25τi) |d⟩',
       ].join('\n'),

--- a/tests/Operator.test.ts
+++ b/tests/Operator.test.ts
@@ -458,4 +458,22 @@ describe('Sparse Complex Operator', () => {
         '(-1.00 +3.00i) |d⟩⟨u| + (0.00 +8.00i) |d⟩⟨d|\n',
     )
   })
+
+  it('creating projections', () => {
+    const vec = Vector.fromSparseCoordNames(
+      [
+        ['u', Cx(1, 0)],
+        ['d', Cx(0, 1)],
+      ],
+      [Dimension.spin()],
+    ).normalize()
+    const proj = Operator.projectionOn(vec)
+    expect(proj.isCloseToProjection()).toBe(true)
+    expect(proj.toString()).toEqual(
+      [
+        'Operator with 4 entries of max size [[2], [2]] with dimensions [[spin], [spin]]',
+        '(0.50 +0.00i) |u⟩⟨u| + (0.00 -0.50i) |u⟩⟨d| + (0.00 +0.50i) |d⟩⟨u| + (0.50 +0.00i) |d⟩⟨d|\n',
+      ].join('\n'),
+    )
+  })
 })

--- a/tests/Photons.test.ts
+++ b/tests/Photons.test.ts
@@ -400,6 +400,65 @@ describe('Photons', () => {
     expect(randomRes.states[0].vector.normSquared()).toBeCloseTo(1)
   })
 
+  it('measurement: Hong-Ou-Mandel', () => {
+    // ..v..
+    // .....
+    // >.\..
+    // ..A..
+
+    const photons = Photons.emptySpace(4, 4)
+      .addPhotonFromIndicator(0, 2, '>', 'H')
+      .addPhotonFromIndicator(2, 0, 'v', 'H')
+    expect(photons.nPhotons).toBe(2)
+
+    const operations: IXYOperator[] = [{ x: 2, y: 2, op: Elements.beamSplitter(135) }]
+    photons.updateOperators(operations)
+    photons.updateMeasurements([{ x: 2, y: 3, nVecs: Photons.allDirectionsVec() }])
+    expect(photons.ketString()).toBe('(0.71 +0.00i) |0,2,>,H,2,0,v,H⟩ + (0.71 +0.00i) |2,0,v,H,0,2,>,H⟩')
+    photons.propagatePhotons().actOnSinglePhotons()
+    photons.propagatePhotons().actOnSinglePhotons()
+    photons.propagatePhotons().actOnSinglePhotons()
+    expect(photons.ketString()).toBe('(0.00 +0.71i) |2,3,v,H,2,3,v,H⟩ + (0.00 +0.71i) |3,2,>,H,3,2,>,H⟩')
+    const measurement = photons.measure()
+    expect(measurement.toString()).toBe(
+      ['50.0% [] 1.00 exp(0.25τi) |3,2,>,H,3,2,>,H⟩', '50.0% [2-3-vH&2-3-vH] 1.00 exp(0.25τi) |⟩'].join('\n'),
+    )
+  })
+
+  it('measurement: Hong-Ou-Mandel at 50% detection', () => {
+    // 50% absorbtion
+    // ..v..
+    // .....
+    // >.\..
+    // ..A..
+
+    const photons = Photons.emptySpace(4, 4)
+      .addPhotonFromIndicator(0, 2, '>', 'H')
+      .addPhotonFromIndicator(2, 0, 'v', 'H')
+    expect(photons.nPhotons).toBe(2)
+
+    const operations: IXYOperator[] = [{ x: 2, y: 2, op: Elements.beamSplitter(135) }]
+    photons.updateOperators(operations)
+    photons.updateMeasurements([{ x: 2, y: 3, nVecs: Photons.allDirectionsVec(Math.SQRT1_2) }])
+    expect(photons.ketString()).toBe('(0.71 +0.00i) |0,2,>,H,2,0,v,H⟩ + (0.71 +0.00i) |2,0,v,H,0,2,>,H⟩')
+    photons.propagatePhotons().actOnSinglePhotons()
+    photons.propagatePhotons().actOnSinglePhotons()
+    photons.propagatePhotons().actOnSinglePhotons()
+    expect(photons.ketString()).toBe('(0.00 +0.71i) |2,3,v,H,2,3,v,H⟩ + (0.00 +0.71i) |3,2,>,H,3,2,>,H⟩')
+    const measurement = photons.measure()
+    expect(measurement.toString()).toBe(
+      [
+        '67.5% [] 0.24 exp(0.25τi) |2,3,v,H,2,3,v,H⟩ + 0.97 exp(0.25τi) |3,2,>,H,3,2,>,H⟩',
+        '12.5% [2-3-vH] 1.00 exp(0.25τi) |2,3,v,H⟩',
+        '7.5% [2-3-vH] 1.00 exp(0.25τi) |2,3,v,H⟩',
+        '12.5% [2-3-vH&2-3-vH] 1.00 exp(0.25τi) |⟩',
+      ].join('\n'),
+    )
+    // WARNING: I am not sure if the result is correct
+    // expected 62.5% + (12.5% + 12.5%) + 12.5%
+    // maybe I still does not understand something with multiple boson absorption, though
+  })
+
   it('performance propagation: size 100x100', () => {
     const photons = Photons.emptySpace(100, 100)
     photons.addPhotonFromIndicator(0, 0, '>', 'H')

--- a/tests/Photons.test.ts
+++ b/tests/Photons.test.ts
@@ -276,6 +276,33 @@ describe('Photons', () => {
     expect(photons.ketString()).toBe('(0.00 +0.50i) |2,2,v,H⟩ + (0.35 +0.00i) |4,0,>,H⟩')
   })
 
+  it('measurement: proj', () => {
+    // 50% absorption filters
+    // >.\.X..
+    // .......
+    // .......
+    // .......
+
+    const photons = Photons.emptySpace(7, 4)
+    photons.addPhotonFromIndicator(0, 0, '>', 'H')
+    const operations: IXYOperator[] = [{ x: 2, y: 0, op: Elements.beamSplitter(135) }]
+    photons.updateOperators(operations)
+    photons.updateMeasurements([{ x: 4, y: 0, nVecs: Photons.allDirectionsVec() }])
+
+    expect(photons.ketString()).toBe('(1.00 +0.00i) |0,0,>,H⟩')
+    photons.propagatePhotons().actOnSinglePhotons()
+    photons.propagatePhotons().actOnSinglePhotons()
+    expect(photons.ketString()).toBe('(0.71 +0.00i) |2,0,>,H⟩ + (0.00 +0.71i) |2,0,v,H⟩')
+    photons.propagatePhotons().actOnSinglePhotons()
+    photons.propagatePhotons().actOnSinglePhotons()
+    expect(photons.ketString()).toBe('(0.00 +0.71i) |2,2,v,H⟩ + (0.71 +0.00i) |4,0,>,H⟩')
+    const measurement = photons.measure()
+    expect(photons.measurementVecs.length).toBe(8)
+    expect(photons.measurementVecs[0].name[0]).toBe('4-0->H')
+    expect(photons.measurementVecs[0].vector.toKetString()).toBe('1.00 exp(0.00τi) |4,0,>,H⟩')
+    expect(measurement.toString()).toBe('50.0% [] 1.00 exp(0.25τi) |2,2,v,H⟩\n50.0% [4-0->H] 1.00 exp(0.00τi) |⟩')
+  })
+
   it('performance propagation: size 100x100', () => {
     const photons = Photons.emptySpace(100, 100)
     photons.addPhotonFromIndicator(0, 0, '>', 'H')


### PR DESCRIPTION
Here comes a class for measurements, that allows to:

- [X] measure only some dimensions
- [X] non-complete measurements (i.e. leaves space for 'undetected')
- [X] cascade measurements (e.g. first one photon, then another)
- [X] pick a random realization
 
I want to add:

- [x] non-destructive measurements (a projection operator, does not remove a particle)
- [x] implement it in Photon

A few questions: 

I am not sure if generic <T> for names is useful, or abstract nonsense. For printing, names as string arrays would be the best. But for Photons, we want to have `{ x, y }` as well.