### PR TITLE
Allow initializing simulation with custom operators, streamline operator functions

### DIFF
--- a/benchmarks/benchmark.ts
+++ b/benchmarks/benchmark.ts
@@ -1,21 +1,19 @@
 // See infos at https://nodejs.org/api/perf_hooks.html#perf_hooks_performance_now
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { performance } = require('perf_hooks')
-import Simulation from '../src/Simulation'
+import Simulation, { generateLaserIndicator } from '../src/Simulation'
 import { grid1, grid2 } from './levels'
 
 console.log('---Running benchmarks---')
-let sim = new Simulation(grid1)
-let laserIndicator = sim.generateLaserIndicator()
-sim.initializeFromIndicator(laserIndicator)
+let sim = Simulation.fromGrid(grid1)
+sim.initializeFromIndicator(generateLaserIndicator(grid1.cells))
 const t0 = performance.now()
 sim.generateFrames(100)
 const t1 = performance.now()
 console.log(`Grid 1 (100 frames) took ${t1 - t0} milliseconds.`)
 
-sim = new Simulation(grid2)
-laserIndicator = sim.generateLaserIndicator()
-sim.initializeFromIndicator(laserIndicator)
+sim = Simulation.fromGrid(grid2)
+sim.initializeFromIndicator(generateLaserIndicator(grid2.cells))
 const t2 = performance.now()
 sim.generateFrames(100)
 const t3 = performance.now()

--- a/benchmarks/levels.ts
+++ b/benchmarks/levels.ts
@@ -1,4 +1,6 @@
-export const grid1 = {
+import { IGrid } from '../src/interfaces'
+
+export const grid1: IGrid = {
   cols: 13,
   rows: 10,
   cells: [
@@ -8,7 +10,6 @@ export const grid1 = {
       element: 'Mirror',
       rotation: 45,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 0,
@@ -16,7 +17,6 @@ export const grid1 = {
       element: 'Mirror',
       rotation: 135,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 2,
@@ -24,7 +24,6 @@ export const grid1 = {
       element: 'Mirror',
       rotation: 45,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 2,
@@ -32,7 +31,6 @@ export const grid1 = {
       element: 'Mirror',
       rotation: 135,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 3,
@@ -40,7 +38,6 @@ export const grid1 = {
       element: 'Laser',
       rotation: 0,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 3,
@@ -48,7 +45,6 @@ export const grid1 = {
       element: 'BeamSplitter',
       rotation: 135,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 3,
@@ -56,7 +52,6 @@ export const grid1 = {
       element: 'Mirror',
       rotation: 45,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 2,
@@ -64,7 +59,6 @@ export const grid1 = {
       element: 'Detector',
       rotation: 90,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 9,
@@ -72,7 +66,6 @@ export const grid1 = {
       element: 'Mirror',
       rotation: 135,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 9,
@@ -80,12 +73,11 @@ export const grid1 = {
       element: 'Mirror',
       rotation: 45,
       polarization: 0,
-      percentage: 0,
     },
   ],
 }
 
-export const grid2 = {
+export const grid2: IGrid = {
   cols: 13,
   rows: 10,
   cells: [
@@ -95,7 +87,6 @@ export const grid2 = {
       element: 'Mirror',
       rotation: 0,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 2,
@@ -103,7 +94,6 @@ export const grid2 = {
       element: 'Mirror',
       rotation: 0,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 2,
@@ -111,7 +101,6 @@ export const grid2 = {
       element: 'Mirror',
       rotation: 0,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 3,
@@ -119,7 +108,6 @@ export const grid2 = {
       element: 'Laser',
       rotation: 0,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 4,
@@ -127,7 +115,6 @@ export const grid2 = {
       element: 'SugarSolution',
       rotation: 0,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 4,
@@ -135,7 +122,6 @@ export const grid2 = {
       element: 'SugarSolution',
       rotation: 0,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 3,
@@ -143,7 +129,6 @@ export const grid2 = {
       element: 'PolarizingBeamSplitter',
       rotation: 180,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 3,
@@ -151,7 +136,6 @@ export const grid2 = {
       element: 'FaradayRotator',
       rotation: 180,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 3,
@@ -159,7 +143,6 @@ export const grid2 = {
       element: 'BeamSplitter',
       rotation: 135,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 3,
@@ -167,7 +150,6 @@ export const grid2 = {
       element: 'BeamSplitter',
       rotation: 135,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 3,
@@ -175,7 +157,6 @@ export const grid2 = {
       element: 'BeamSplitter',
       rotation: 135,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 3,
@@ -183,7 +164,6 @@ export const grid2 = {
       element: 'Mirror',
       rotation: 90,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 4,
@@ -191,7 +171,6 @@ export const grid2 = {
       element: 'Mirror',
       rotation: 90,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 4,
@@ -199,7 +178,6 @@ export const grid2 = {
       element: 'BeamSplitter',
       rotation: 135,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 4,
@@ -207,7 +185,6 @@ export const grid2 = {
       element: 'BeamSplitter',
       rotation: 135,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 4,
@@ -215,7 +192,6 @@ export const grid2 = {
       element: 'BeamSplitter',
       rotation: 135,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 4,
@@ -223,7 +199,6 @@ export const grid2 = {
       element: 'Mirror',
       rotation: 90,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 5,
@@ -231,7 +206,6 @@ export const grid2 = {
       element: 'Mirror',
       rotation: 90,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 5,
@@ -239,7 +213,6 @@ export const grid2 = {
       element: 'BeamSplitter',
       rotation: 135,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 5,
@@ -247,7 +220,6 @@ export const grid2 = {
       element: 'BeamSplitter',
       rotation: 135,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 5,
@@ -255,7 +227,6 @@ export const grid2 = {
       element: 'BeamSplitter',
       rotation: 135,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 5,
@@ -263,7 +234,6 @@ export const grid2 = {
       element: 'Detector',
       rotation: 90,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 6,
@@ -271,7 +241,6 @@ export const grid2 = {
       element: 'Mirror',
       rotation: 0,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 6,
@@ -279,7 +248,6 @@ export const grid2 = {
       element: 'Mirror',
       rotation: 0,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 6,
@@ -287,7 +255,6 @@ export const grid2 = {
       element: 'Mirror',
       rotation: 0,
       polarization: 0,
-      percentage: 0,
     },
     {
       y: 5,
@@ -295,7 +262,6 @@ export const grid2 = {
       element: 'Mirror',
       rotation: 90,
       polarization: 0,
-      percentage: 0,
     },
   ],
 }

--- a/src/Bell.ts
+++ b/src/Bell.ts
@@ -2,6 +2,7 @@ import { Cx } from './Complex'
 import Dimension from './Dimension'
 import Vector from './Vector'
 import Operator from './Operator'
+import { DEG_TO_RAD } from './Constants'
 
 // takem from Quantum Boxing
 // https://github.com/sneakyweasel/quantum-boxing
@@ -62,8 +63,8 @@ export const opZ = Operator.fromSparseCoordNames(
 function linearPol(alpha: number): Vector {
   return Vector.fromSparseCoordNames(
     [
-      ['H', Cx(Math.cos((2 * Math.PI * alpha) / 360))],
-      ['V', Cx(Math.sin((2 * Math.PI * alpha) / 360))],
+      ['H', Cx(Math.cos(alpha * DEG_TO_RAD))],
+      ['V', Cx(Math.sin(alpha * DEG_TO_RAD))],
     ],
     [dimPol],
   )

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,1 +1,2 @@
 export const TAU = 2 * Math.PI
+export const DEG_TO_RAD = TAU / 360

--- a/src/Ops.ts
+++ b/src/Ops.ts
@@ -182,6 +182,11 @@ export function beamsplitterTransmittionDirections(angle: number): Operator {
   }
 }
 
+const diodeRight = Operator.fromSparseCoordNames([['>', '>', Cx(1)]], [dimDir])
+const diodeUp = Operator.fromSparseCoordNames([['^', '^', Cx(1)]], [dimDir])
+const diodeLeft = Operator.fromSparseCoordNames([['<', '<', Cx(1)]], [dimDir])
+const diodeDown = Operator.fromSparseCoordNames([['v', 'v', Cx(1)]], [dimDir])
+
 /**
  * An auxiliary operation for constructing other directional operators.
  * @param angle Angle in degrees [0, 90, 180, 270] up to 360. --> and CCW.
@@ -190,13 +195,13 @@ export function beamsplitterTransmittionDirections(angle: number): Operator {
 export function diodeForDirections(angle: number): Operator {
   switch (mod(angle, 360)) {
     case 0: // ->
-      return Operator.fromSparseCoordNames([['>', '>', Cx(1)]], [dimDir])
+      return diodeRight
     case 90: // ^
-      return Operator.fromSparseCoordNames([['^', '^', Cx(1)]], [dimDir])
+      return diodeUp
     case 180: // <-
-      return Operator.fromSparseCoordNames([['<', '<', Cx(1)]], [dimDir])
+      return diodeLeft
     case 270: // v
-      return Operator.fromSparseCoordNames([['v', 'v', Cx(1)]], [dimDir])
+      return diodeDown
     default:
       throw new Error(`Angle ${angle} % 360 isn't in the set [0, 90, 180, 270].`)
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -120,6 +120,7 @@ export interface IGrid {
   rows: number
   cells: ICell[]
 }
+/* eslint-disable */
 
 /**
  * Cell interface in primitives

--- a/tests/Elements.test.ts
+++ b/tests/Elements.test.ts
@@ -128,27 +128,17 @@ describe('Optical elements', () => {
     expect(Elements.faradayRotator(270).isCloseToHermitian()).toBe(false)
   })
 
-  it('Polarizers WE and NS', () => {
-    expect(Elements.polarizerWE(0).isCloseToProjection()).toBe(true)
-    expect(Elements.polarizerWE(45).isCloseToProjection()).toBe(true)
-    expect(Elements.polarizerWE(90).isCloseToProjection()).toBe(true)
-    expect(Elements.polarizerWE(135).isCloseToProjection()).toBe(true)
-
-    expect(Elements.polarizerNS(0).isCloseToProjection()).toBe(true)
-    expect(Elements.polarizerNS(45).isCloseToProjection()).toBe(true)
-    expect(Elements.polarizerNS(90).isCloseToProjection()).toBe(true)
-    expect(Elements.polarizerNS(135).isCloseToProjection()).toBe(true)
+  it('Polarizers', () => {
+    expect(Elements.polarizer(0).isCloseToProjection()).toBe(true)
+    expect(Elements.polarizer(45).isCloseToProjection()).toBe(true)
+    expect(Elements.polarizer(90).isCloseToProjection()).toBe(true)
+    expect(Elements.polarizer(135).isCloseToProjection()).toBe(true)
   })
 
-  it('Quarter wave plates WE and NS', () => {
-    expect(Elements.quarterWavePlateWE(0).isCloseToUnitaryOnSubspace()).toBe(true)
-    expect(Elements.quarterWavePlateWE(45).isCloseToUnitaryOnSubspace()).toBe(true)
-    expect(Elements.quarterWavePlateWE(90).isCloseToUnitaryOnSubspace()).toBe(true)
-    expect(Elements.quarterWavePlateWE(135).isCloseToUnitaryOnSubspace()).toBe(true)
-
-    expect(Elements.quarterWavePlateNS(0).isCloseToUnitaryOnSubspace()).toBe(true)
-    expect(Elements.quarterWavePlateNS(45).isCloseToUnitaryOnSubspace()).toBe(true)
-    expect(Elements.quarterWavePlateNS(90).isCloseToUnitaryOnSubspace()).toBe(true)
-    expect(Elements.quarterWavePlateNS(135).isCloseToUnitaryOnSubspace()).toBe(true)
+  it('Quarter wave plates', () => {
+    expect(Elements.phasePlate(0, 0.25).isCloseToUnitaryOnSubspace()).toBe(true)
+    expect(Elements.phasePlate(45, 0.25).isCloseToUnitaryOnSubspace()).toBe(true)
+    expect(Elements.phasePlate(90, 0.25).isCloseToUnitaryOnSubspace()).toBe(true)
+    expect(Elements.phasePlate(135, 0.25).isCloseToUnitaryOnSubspace()).toBe(true)
   })
 })

--- a/tests/Simulation.test.ts
+++ b/tests/Simulation.test.ts
@@ -1,40 +1,39 @@
-import Simulation from '../src/Simulation'
+import Simulation, { generateLaserIndicator } from '../src/Simulation'
 import Operator from '../src/Operator'
+import { Elem, IGrid } from '../src/interfaces'
 
-const grid1 = {
+const grid1: IGrid = {
   cols: 13,
   rows: 10,
   cells: [
     {
       x: 3,
       y: 2,
-      element: 'Laser',
+      element: Elem.Laser,
       rotation: 0,
       polarization: 0,
-      strength: 0,
     },
     {
       x: 9,
       y: 2,
-      element: 'Detector',
+      element: Elem.Detector,
       rotation: 180,
       polarization: 0,
-      strength: 0,
     },
   ],
 }
 
 describe('Simulation', () => {
   it('creates a simulation', () => {
-    const sim = new Simulation(grid1)
+    const sim = Simulation.fromGrid(grid1)
     expect(sim.frames).toStrictEqual([])
     expect(sim.operators).toHaveLength(2)
     expect(sim.globalOperator).toBeInstanceOf(Operator)
   })
 
   it('Creates an initial frame by firing the laz0rs', () => {
-    const sim = new Simulation(grid1)
-    const laserIndicator = sim.generateLaserIndicator()
+    const sim = Simulation.fromGrid(grid1)
+    const laserIndicator = generateLaserIndicator(grid1.cells)
     sim.initializeFromIndicator(laserIndicator)
     expect(sim.frames).toHaveLength(1)
     expect(sim.frames[0].particles).toHaveLength(1)
@@ -51,8 +50,8 @@ describe('Simulation', () => {
   })
 
   it('should propagate the photon', () => {
-    const sim = new Simulation(grid1)
-    const laserIndicator = sim.generateLaserIndicator()
+    const sim = Simulation.fromGrid(grid1)
+    const laserIndicator = generateLaserIndicator(grid1.cells)
     sim.initializeFromIndicator(laserIndicator)
     sim.frames.push(sim.nextFrame())
     expect(sim.lastFrame.particles).toHaveLength(1)
@@ -69,8 +68,8 @@ describe('Simulation', () => {
   })
 
   it('should generate frames', () => {
-    const sim = new Simulation(grid1)
-    const laserIndicator = sim.generateLaserIndicator()
+    const sim = Simulation.fromGrid(grid1)
+    const laserIndicator = generateLaserIndicator(grid1.cells)
     sim.initializeFromIndicator(laserIndicator)
     sim.generateFrames()
     expect(sim.frames).toHaveLength(7)


### PR DESCRIPTION
Those changes are necessary for QG to allow free modification of operator functions, thus allowing parametrization out of scope of QT API.

The alternative was to move the whole `Simulation` class into QG, but I decided against that for now for simplicity's sake.